### PR TITLE
docs: add package version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Available as:
 - CLI (see [Usage](#usage))
 - Python library (see [Python Bindings](#python-bindings))
 
-![Codecov](https://img.shields.io/codecov/c/github/kantord/headson?style=flat-square)
+![Codecov](https://img.shields.io/codecov/c/github/kantord/headson?style=flat-square) ![Crates.io Version](https://img.shields.io/crates/v/headson?style=flat-square) ![PyPI - Version](https://img.shields.io/pypi/v/headson?style=flat-square)
+
 
 ## Install
 


### PR DESCRIPTION
Added version badges for Crates.io and PyPI to README.