### PR TITLE
chore: release v0.7.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.28](https://github.com/kantord/headson/compare/headson-v0.7.27...headson-v0.7.28) - 2025-11-24
+
+### Fixed
+
+- improve line duplication logic ([#304](https://github.com/kantord/headson/pull/304))
+
 ## [0.7.27](https://github.com/kantord/headson/compare/headson-v0.7.26...headson-v0.7.27) - 2025-11-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.7.27"
+version = "0.7.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.7.27"
+version = "0.7.28"
 dependencies = [
  "anyhow",
  "headson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.27"
+version = "0.7.28"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.7.27 -> 0.7.28 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.28](https://github.com/kantord/headson/compare/headson-v0.7.27...headson-v0.7.28) - 2025-11-24

### Fixed

- improve line duplication logic ([#304](https://github.com/kantord/headson/pull/304))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).