### PR TITLE
chore: release v0.7.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.29](https://github.com/kantord/headson/compare/headson-v0.7.28...headson-v0.7.29) - 2025-11-25
+
+### Added
+
+- implement glob feature ([#308](https://github.com/kantord/headson/pull/308))
+
 ## [0.7.28](https://github.com/kantord/headson/compare/headson-v0.7.27...headson-v0.7.28) - 2025-11-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "anyhow",
  "headson",
@@ -2195,18 +2195,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.28"
+version = "0.7.29"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.7.28 -> 0.7.29 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.29](https://github.com/kantord/headson/compare/headson-v0.7.28...headson-v0.7.29) - 2025-11-25

### Added

- implement glob feature ([#308](https://github.com/kantord/headson/pull/308))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).