### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/kantord/headson/compare/headson-v0.7.29...headson-v0.8.0) - 2025-11-25
+
+### Added
+
+- implement --grep flag ([#312](https://github.com/kantord/headson/pull/312))
+
 ## [0.7.29](https://github.com/kantord/headson/compare/headson-v0.7.28...headson-v0.7.29) - 2025-11-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.7.29"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.7.29"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "headson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.29"
+version = "0.8.0"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.7.29 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `headson` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  headson::headson now takes 5 parameters instead of 4, in /tmp/.tmpOIkkrN/headson/src/lib.rs:57
  headson::find_largest_render_under_budgets now takes 4 parameters instead of 3, in /tmp/.tmpOIkkrN/headson/src/pruner/budget.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/kantord/headson/compare/headson-v0.7.29...headson-v0.8.0) - 2025-11-25

### Added

- implement --grep flag ([#312](https://github.com/kantord/headson/pull/312))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).