### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/kantord/headson/compare/headson-v0.8.0...headson-v0.9.0) - 2025-11-29
+
+### Added
+
+- allow showing unmatched files in --grep mode ([#321](https://github.com/kantord/headson/pull/321))
+- implement highlighting for grep results ([#313](https://github.com/kantord/headson/pull/313))
+
+### Fixed
+
+- by default, hide files with 0 matches when using --grep ([#317](https://github.com/kantord/headson/pull/317))
+
+### Other
+
+- *(deps)* update rust crate insta to v1.44.3 ([#318](https://github.com/kantord/headson/pull/318))
+
 ## [0.8.0](https://github.com/kantord/headson/compare/headson-v0.7.29...headson-v0.8.0) - 2025-11-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "headson",
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1886,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1899,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `headson` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GrepConfig.show in /tmp/.tmpgMwXfx/headson/src/grep.rs:19
  field RenderConfig.grep_highlight in /tmp/.tmpgMwXfx/headson/src/serialization/types.rs:51

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type RenderConfig no longer derives Eq, in /tmp/.tmpgMwXfx/headson/src/serialization/types.rs:20
  type RenderConfig no longer derives PartialEq, in /tmp/.tmpgMwXfx/headson/src/serialization/types.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/kantord/headson/compare/headson-v0.8.0...headson-v0.9.0) - 2025-11-29

### Added

- allow showing unmatched files in --grep mode ([#321](https://github.com/kantord/headson/pull/321))
- implement highlighting for grep results ([#313](https://github.com/kantord/headson/pull/313))

### Fixed

- by default, hide files with 0 matches when using --grep ([#317](https://github.com/kantord/headson/pull/317))

### Other

- *(deps)* update rust crate insta to v1.44.3 ([#318](https://github.com/kantord/headson/pull/318))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).