### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/kantord/headson/compare/headson-v0.9.0...headson-v0.10.0) - 2025-12-01
+
+### Added
+
+- add --tree flag ([#326](https://github.com/kantord/headson/pull/326))
+
 ## [0.9.0](https://github.com/kantord/headson/compare/headson-v0.8.0...headson-v0.9.0) - 2025-11-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "headson",
@@ -2209,18 +2209,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `headson` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RenderConfig.fileset_tree in /tmp/.tmpkn3jlR/headson/src/serialization/types.rs:49
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/kantord/headson/compare/headson-v0.9.0...headson-v0.10.0) - 2025-12-01

### Added

- add --tree flag ([#326](https://github.com/kantord/headson/pull/326))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).