### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/kantord/headson/compare/headson-v0.10.0...headson-v0.10.1) - 2025-12-04
+
+### Fixed
+
+- stop cross-file duplicate penalty starving filesets ([#334](https://github.com/kantord/headson/pull/334))
+
+### Other
+
+- deduplicate helpers ([#329](https://github.com/kantord/headson/pull/329))
+
 ## [0.10.0](https://github.com/kantord/headson/compare/headson-v0.9.0...headson-v0.10.0) - 2025-12-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "headson",
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libgit2-sys"
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.10.0 -> 0.10.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.1](https://github.com/kantord/headson/compare/headson-v0.10.0...headson-v0.10.1) - 2025-12-04

### Fixed

- stop cross-file duplicate penalty starving filesets ([#334](https://github.com/kantord/headson/pull/334))

### Other

- deduplicate helpers ([#329](https://github.com/kantord/headson/pull/329))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).