### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/kantord/headson/compare/headson-v0.10.1...headson-v0.11.0) - 2025-12-11
+
+### Added
+
+- stricter enforcement for per-file caps ([#344](https://github.com/kantord/headson/pull/344))
+
 ## [0.10.1](https://github.com/kantord/headson/compare/headson-v0.10.0...headson-v0.10.1) - 2025-12-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "headson",
@@ -756,9 +756,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1544,9 +1544,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simd-json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `headson` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Budgets.global in /tmp/.tmpWOyiJR/headson/src/pruner/budget.rs:24
  field Budgets.per_slot in /tmp/.tmpWOyiJR/headson/src/pruner/budget.rs:25

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field force_first_child of struct PriorityOrder, previously in file /tmp/.tmpoIgnIG/headson/src/order/types.rs:179
  field byte_budget of struct Budgets, previously in file /tmp/.tmpoIgnIG/headson/src/pruner/budget.rs:10
  field char_budget of struct Budgets, previously in file /tmp/.tmpoIgnIG/headson/src/pruner/budget.rs:11
  field line_budget of struct Budgets, previously in file /tmp/.tmpoIgnIG/headson/src/pruner/budget.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/kantord/headson/compare/headson-v0.10.1...headson-v0.11.0) - 2025-12-11

### Added

- stricter enforcement for per-file caps ([#344](https://github.com/kantord/headson/pull/344))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).