### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/kantord/headson/compare/headson-v0.11.1...headson-v0.11.2) - 2025-12-16
+
+### Other
+
+- split text ingest pipeline ([#386](https://github.com/kantord/headson/pull/386))
+- tidy CLI/debug flow and add CLI golden snapshots ([#384](https://github.com/kantord/headson/pull/384))
+- simplify serialization and guard slot stats ([#383](https://github.com/kantord/headson/pull/383))
+- stabilize fileset interleave and duplicate penalties ([#381](https://github.com/kantord/headson/pull/381))
+
 ## [0.11.1](https://github.com/kantord/headson/compare/headson-v0.11.0...headson-v0.11.1) - 2025-12-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "headson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.11.1 -> 0.11.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.2](https://github.com/kantord/headson/compare/headson-v0.11.1...headson-v0.11.2) - 2025-12-16

### Other

- split text ingest pipeline ([#386](https://github.com/kantord/headson/pull/386))
- tidy CLI/debug flow and add CLI golden snapshots ([#384](https://github.com/kantord/headson/pull/384))
- simplify serialization and guard slot stats ([#383](https://github.com/kantord/headson/pull/383))
- stabilize fileset interleave and duplicate penalties ([#381](https://github.com/kantord/headson/pull/381))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).