### PR TITLE
chore: release v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/kantord/headson/compare/headson-v0.11.2...headson-v0.11.3) - 2025-12-18
+
+### Fixed
+
+- *(deps)* update rust crate yaml-rust2 to 0.11 ([#387](https://github.com/kantord/headson/pull/387))
+
+### Other
+
+- improve readme ([#399](https://github.com/kantord/headson/pull/399))
+- document source code support ([#398](https://github.com/kantord/headson/pull/398))
+- simplify features section in README.md ([#395](https://github.com/kantord/headson/pull/395))
+- add tape about sorting ([#397](https://github.com/kantord/headson/pull/397))
+- docs improvements ([#394](https://github.com/kantord/headson/pull/394))
+- add additional demo tapes ([#392](https://github.com/kantord/headson/pull/392))
+- add navigation bar ([#389](https://github.com/kantord/headson/pull/389))
+
 ## [0.11.2](https://github.com/kantord/headson/compare/headson-v0.11.1...headson-v0.11.2) - 2025-12-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "headson",
@@ -904,13 +904,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall 0.6.0",
 ]
 
 [[package]]
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
 dependencies = [
  "bitflags 2.10.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.2"
+version = "0.11.3"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.11.2 -> 0.11.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.3](https://github.com/kantord/headson/compare/headson-v0.11.2...headson-v0.11.3) - 2025-12-18

### Fixed

- *(deps)* update rust crate yaml-rust2 to 0.11 ([#387](https://github.com/kantord/headson/pull/387))

### Other

- improve readme ([#399](https://github.com/kantord/headson/pull/399))
- document source code support ([#398](https://github.com/kantord/headson/pull/398))
- simplify features section in README.md ([#395](https://github.com/kantord/headson/pull/395))
- add tape about sorting ([#397](https://github.com/kantord/headson/pull/397))
- docs improvements ([#394](https://github.com/kantord/headson/pull/394))
- add additional demo tapes ([#392](https://github.com/kantord/headson/pull/392))
- add navigation bar ([#389](https://github.com/kantord/headson/pull/389))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).