### PR TITLE
chore: release v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/kantord/headson/compare/headson-v0.11.3...headson-v0.11.4) - 2025-12-18
+
+### Other
+
+- small fixes ([#400](https://github.com/kantord/headson/pull/400))
+
 ## [0.11.3](https://github.com/kantord/headson/compare/headson-v0.11.2...headson-v0.11.3) - 2025-12-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "headson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.3"
+version = "0.11.4"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.11.3 -> 0.11.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.4](https://github.com/kantord/headson/compare/headson-v0.11.3...headson-v0.11.4) - 2025-12-18

### Other

- small fixes ([#400](https://github.com/kantord/headson/pull/400))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).