### PR TITLE
chore: release v0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/kantord/headson/compare/headson-v0.11.4...headson-v0.11.5) - 2025-12-20
+
+### Added
+
+- add shell completions ([#406](https://github.com/kantord/headson/pull/406))
+
+### Other
+
+- drop git2 network features and tidy fileset ordering tests ([#412](https://github.com/kantord/headson/pull/412))
+- *(deps)* update rust crate frecenfile to v0.4.1 ([#410](https://github.com/kantord/headson/pull/410))
+- turn off default features in git2 ([#407](https://github.com/kantord/headson/pull/407))
+
 ## [0.11.4](https://github.com/kantord/headson/compare/headson-v0.11.3...headson-v0.11.4) - 2025-12-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "headson",
@@ -1400,9 +1400,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.4"
+version = "0.11.5"
 
 [package]
 name = "headson"


### PR DESCRIPTION



## 🤖 New release

* `headson`: 0.11.4 -> 0.11.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.5](https://github.com/kantord/headson/compare/headson-v0.11.4...headson-v0.11.5) - 2025-12-20

### Added

- add shell completions ([#406](https://github.com/kantord/headson/pull/406))

### Other

- drop git2 network features and tidy fileset ordering tests ([#412](https://github.com/kantord/headson/pull/412))
- *(deps)* update rust crate frecenfile to v0.4.1 ([#410](https://github.com/kantord/headson/pull/410))
- turn off default features in git2 ([#407](https://github.com/kantord/headson/pull/407))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).