### PR TITLE
feat(cli): Shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +635,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "content_inspector",
  "filetime",
  "frecenfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ yaml-rust2 = "0.11"
 once_cell = "1.19"
 syntect = "5"
 regex = "1.11"
+clap_complete = "4.5.62"
 
  
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, Parser, ValueEnum};
+use clap_complete::Shell;
 
 /// Top-level CLI flags and enums.
 #[derive(Parser, Debug)]
@@ -186,6 +187,13 @@ pub struct Cli {
         help = "When using --grep, control fileset inclusion: matching (default) | all"
     )]
     pub grep_show: GrepShowArg,
+    #[arg(
+        long = "completions",
+        value_name = "SHELL",
+        value_enum,
+        help = "Print shell completions for the given shell"
+    )]
+    pub completions: Option<Shell>,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
@@ -298,4 +306,18 @@ pub(crate) fn map_grep_show(show: GrepShowArg) -> headson::GrepShow {
         GrepShowArg::Matching => headson::GrepShow::Matching,
         GrepShowArg::All => headson::GrepShow::All,
     }
+}
+
+/// See also
+/// <https://github.com/clap-rs/clap/blob/f65d421607ba16c3175ffe76a20820f123b6c4cb/clap_complete/examples/completion-derive.rs#L69>.
+pub fn print_completions<G: clap_complete::Generator>(
+    generator: G,
+    cmd: &mut clap::Command,
+) {
+    clap_complete::generate(
+        generator,
+        cmd,
+        cmd.get_name().to_string(),
+        &mut std::io::stdout(),
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,19 @@ mod cli;
 mod sorting;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 use crate::cli::args::Cli;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if let Some(shell) = cli.completions {
+        eprintln!("generating completions file for {shell:?}");
+        cli::args::print_completions(shell, &mut Cli::command());
+
+        return Ok(());
+    }
 
     let (output, ignore_notices) = crate::cli::run::run(&cli)?;
     println!("{output}");


### PR DESCRIPTION
via `clap_complete`, see also <https://docs.rs/clap_complete/latest/clap_complete/#example>

For example, on `fish` this looks like:

<img width="1728" height="529" alt="image" src="https://github.com/user-attachments/assets/b8b25942-6161-4c0a-9235-83f1765a8b0c" />
