### PR TITLE
build: turn off default features in git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ unicode-segmentation = "1.12.0"
 simd-json = { version = "0.17", features = ["serde_impl"] }
 content_inspector = "0.2"
 frecenfile = "0.4"
-git2 = { version = "0.20.1", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.20.1", default-features = false, features = ["vendored-libgit2", "vendored-openssl"] }
 ignore = "0.4"
 yaml-rust2 = "0.11"
 once_cell = "1.19"


### PR DESCRIPTION
`ssh` and `https` are `default` features of `git2`: <https://docs.rs/crate/git2/latest/features#default>.

Building `headson` can fail if Perl isn't available, as openssl is built, which needs Perl. `headson` doesn't need git network access, so it seems straightforward and safer to just remove the `ssh` and `https` network features.

I left the `vendored-` libs in as they're still required for successful independent compilation it seems.