### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/kantord/headson/compare/headson-v0.16.0...headson-v0.16.1) - 2026-02-02
+
+### Other
+
+- optimize sampling for grep mode in jsonl files ([#504](https://github.com/kantord/headson/pull/504))
+
 ## [0.16.0](https://github.com/kantord/headson/compare/headson-v0.15.0...headson-v0.16.0) - 2026-02-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "headson"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "headson-python"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "headson",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "prunist"
-version = "0.16.0"
+version = "0.16.1"
 
 [[package]]
 name = "pyo3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 
 [package]
 name = "headson"
@@ -47,7 +47,7 @@ once_cell = "1.19"
 syntect = "5"
 regex = "1.11"
 clap_complete = "4.5.62"
-prunist = { path = "crates/prunist", version = "0.16.0" }
+prunist = { path = "crates/prunist", version = "0.16.1" }
 
  
 


### PR DESCRIPTION



## 🤖 New release

* `prunist`: 0.16.0 -> 0.16.1
* `headson`: 0.16.0 -> 0.16.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `headson`

<blockquote>

## [0.16.1](https://github.com/kantord/headson/compare/headson-v0.16.0...headson-v0.16.1) - 2026-02-02

### Other

- optimize sampling for grep mode in jsonl files ([#504](https://github.com/kantord/headson/pull/504))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).